### PR TITLE
fix(auth): fix token refresh loop and stale token reuse on login

### DIFF
--- a/API/opensis.core/User/Services/UserService.cs
+++ b/API/opensis.core/User/Services/UserService.cs
@@ -66,27 +66,18 @@ namespace opensis.core.User.Services
                 ReturnModel = this.userRepository.ValidateUserLogin(ObjModel);
                 if (ReturnModel._failure == false)
                 {
-                    var existToken = tokenManager.CheckTokenInLogin(ReturnModel.Email, ReturnModel.TenantId, ReturnModel._tenantName + ReturnModel.Name);
-                    if (existToken != null)
+                    var tokenInfo = TokenManager.GenerateTokenWithExpiry(ReturnModel._tenantName + ReturnModel.Name + "|" + ReturnModel.Email + "|" + ReturnModel.TenantId);
+                    ReturnModel._token = tokenInfo.Token;
+                    ReturnModel._tokenExpiry = tokenInfo.Expiry;
+                    if (this.userRepository.AddLoginSession(ReturnModel))
                     {
-                        ReturnModel._token = existToken;
+                        logger.Info("Method ValidateLogin end with success.");
                     }
                     else
                     {
-                        var tokenInfo = TokenManager.GenerateTokenWithExpiry(ReturnModel._tenantName + ReturnModel.Name + "|" + ReturnModel.Email + "|" + ReturnModel.TenantId);
-                        // ReturnModel._token = TokenManager.GenerateToken(ReturnModel._tenantName);
-                        ReturnModel._token = tokenInfo.Token;
-                        ReturnModel._tokenExpiry = tokenInfo.Expiry;
-                        if (this.userRepository.AddLoginSession(ReturnModel))
-                        {
-                            logger.Info("Method ValidateLogin end with success.");
-                        }
-                        else
-                        {
-                            ReturnModel._token = null;
-                            logger.Info("Method ValidateLogin end with error");
-                            ReturnModel._failure = true;
-                        }
+                        ReturnModel._token = null;
+                        logger.Info("Method ValidateLogin end with error");
+                        ReturnModel._failure = true;
                     }
                 }
             }

--- a/UI/src/app/app.component.ts
+++ b/UI/src/app/app.component.ts
@@ -702,8 +702,8 @@ export class AppComponent implements OnInit, OnDestroy {
     let date1: any = new Date(decoded.exp * 1000)
     let date2: any = new Date();
     let res = Math.abs(date1 - date2) / 1000;
-    this.minutes = Math.floor(res / 60) % 60;
-    this.tokenEndTime = (this.minutes - 2) * 60;
+    this.minutes = Math.floor(res / 60);
+    this.tokenEndTime = Math.max((this.minutes - 2) * 60, 60);
     this.tokenExpired = Date.now() > (decoded.exp * 1000 - 120000);
     if(this.tokenExpired) {
       this.logout();


### PR DESCRIPTION
Remove % 60 from tokenEndTime calculation that discarded hours, causing negative ping interval and infinite refresh loop for fresh 24-hour tokens (1440 % 60 = 0). Always generate a fresh token on login instead of reusing a previous session's potentially near-expiry token.

Resolves #813