### PR TITLE
feat(calendar): scope "Apply to All Schools" to user's authorized sch…

### DIFF
--- a/API/opensis.data/Repository/CalendarEventRepository.cs
+++ b/API/opensis.data/Repository/CalendarEventRepository.cs
@@ -23,6 +23,7 @@ Copyright (c) Open Solutions for Education, Inc.
 All rights reserved.
 ***********************************************************************************/
 
+using Microsoft.EntityFrameworkCore;
 using opensis.data.Helper;
 using opensis.data.Interface;
 using opensis.data.Models;
@@ -65,6 +66,133 @@ namespace opensis.data.Repository
             calendarEvent.SchoolCalendarEvent!.AcademicYear = Utility.GetCurrentAcademicYear(this.context!, calendarEvent.SchoolCalendarEvent.TenantId, calendarEvent.SchoolCalendarEvent.SchoolId);
             calendarEvent.SchoolCalendarEvent!.EventId = (int)eventId;
             calendarEvent.SchoolCalendarEvent.CreatedOn = DateTime.UtcNow;
+
+            // When "Apply to All Schools" is requested, scope to the creator's authorized schools.
+            // Super Admins keep the system-wide flag (visible to all schools).
+            // School Admins get individual copies at each school they administer.
+            if (calendarEvent.SchoolCalendarEvent.ApplicableToAllSchool == true
+                || calendarEvent.SchoolCalendarEvent.SystemWideEvent == true)
+            {
+                var staffMember = this.context?.StaffMaster
+                    .FirstOrDefault(s => s.TenantId == calendarEvent.SchoolCalendarEvent.TenantId
+                        && s.StaffGuid.ToString() == calendarEvent.SchoolCalendarEvent.CreatedBy);
+
+                if (staffMember != null)
+                {
+                    var activeAssignments = this.context?.StaffSchoolInfo
+                        .Include(s => s.Membership)
+                        .Where(s => s.TenantId == calendarEvent.SchoolCalendarEvent.TenantId
+                            && s.StaffId == staffMember.StaffId
+                            && (s.EndDate == null || s.EndDate.Value.Date >= DateTime.UtcNow.Date)
+                            && s.StartDate <= DateTime.UtcNow.Date)
+                        .ToList();
+
+                    // Check Super Admin via StaffSchoolInfo first, then fall back to UserMaster
+                    // (Super Admins may not have StaffSchoolInfo entries — they access all schools via UserMaster.Membership)
+                    var isSuperAdmin = activeAssignments?.Any(s =>
+                        string.Equals(s.Membership?.ProfileType, "Super Administrator", StringComparison.OrdinalIgnoreCase)) ?? false;
+
+                    if (!isSuperAdmin)
+                    {
+                        isSuperAdmin = this.context?.UserMaster
+                            .Include(u => u.Membership)
+                            .Any(u => u.TenantId == calendarEvent.SchoolCalendarEvent.TenantId
+                                && u.UserId == staffMember.StaffId
+                                && (u.Membership!.IsSuperadmin == true
+                                    || u.Membership.ProfileType!.ToLower() == "super administrator")) ?? false;
+                    }
+
+                    if (!isSuperAdmin)
+                    {
+                        // Other schools where this user is School Administrator
+                        var targetSchoolIds = activeAssignments?
+                            .Where(s => string.Equals(s.Membership?.ProfileType, "School Administrator", StringComparison.OrdinalIgnoreCase)
+                                && s.SchoolAttachedId != null
+                                && s.SchoolAttachedId != calendarEvent.SchoolCalendarEvent.SchoolId)
+                            .Select(s => s.SchoolAttachedId!.Value)
+                            .Distinct()
+                            .ToList() ?? new List<int>();
+
+                        // Resolve source membership profile types for visibility translation (events only)
+                        List<string?>? sourceProfileTypes = null;
+                        if (!string.IsNullOrEmpty(calendarEvent.SchoolCalendarEvent.VisibleToMembershipId)
+                            && calendarEvent.SchoolCalendarEvent.IsHoliday != true)
+                        {
+                            var sourceMembershipIds = calendarEvent.SchoolCalendarEvent.VisibleToMembershipId
+                                .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                                .Select(int.Parse)
+                                .ToList();
+
+                            sourceProfileTypes = this.context?.Membership
+                                .Where(m => m.TenantId == calendarEvent.SchoolCalendarEvent.TenantId
+                                    && m.SchoolId == calendarEvent.SchoolCalendarEvent.SchoolId
+                                    && sourceMembershipIds.Contains(m.MembershipId))
+                                .Select(m => m.ProfileType)
+                                .ToList();
+                        }
+
+                        // Copies are standalone records, not system-wide
+                        calendarEvent.SchoolCalendarEvent.ApplicableToAllSchool = false;
+                        calendarEvent.SchoolCalendarEvent.SystemWideEvent = false;
+
+                        foreach (var targetSchoolId in targetSchoolIds)
+                        {
+                            // Find the default calendar at the target school for the same academic year
+                            var targetCalendar = this.context?.SchoolCalendars
+                                .FirstOrDefault(c => c.TenantId == calendarEvent.SchoolCalendarEvent.TenantId
+                                    && c.SchoolId == targetSchoolId
+                                    && c.AcademicYear == calendarEvent.SchoolCalendarEvent.AcademicYear
+                                    && c.DefaultCalender == true)
+                                ?? this.context?.SchoolCalendars
+                                    .FirstOrDefault(c => c.TenantId == calendarEvent.SchoolCalendarEvent.TenantId
+                                        && c.SchoolId == targetSchoolId
+                                        && c.AcademicYear == calendarEvent.SchoolCalendarEvent.AcademicYear);
+
+                            if (targetCalendar == null) continue;
+
+                            // Translate membership visibility to the target school
+                            string? targetVisibleToMembershipId = calendarEvent.SchoolCalendarEvent.VisibleToMembershipId;
+                            if (sourceProfileTypes != null)
+                            {
+                                var targetMembershipIds = this.context?.Membership
+                                    .Where(m => m.TenantId == calendarEvent.SchoolCalendarEvent.TenantId
+                                        && m.SchoolId == targetSchoolId
+                                        && sourceProfileTypes.Contains(m.ProfileType))
+                                    .Select(m => m.MembershipId)
+                                    .ToList() ?? new List<int>();
+
+                                targetVisibleToMembershipId = string.Join(",", targetMembershipIds);
+                            }
+
+                            eventId++;
+                            var copy = new CalendarEvents
+                            {
+                                TenantId = calendarEvent.SchoolCalendarEvent.TenantId,
+                                SchoolId = targetSchoolId,
+                                CalendarId = targetCalendar.CalenderId,
+                                EventId = (int)eventId,
+                                AcademicYear = calendarEvent.SchoolCalendarEvent.AcademicYear,
+                                StartDate = calendarEvent.SchoolCalendarEvent.StartDate,
+                                EndDate = calendarEvent.SchoolCalendarEvent.EndDate,
+                                SchoolDate = calendarEvent.SchoolCalendarEvent.SchoolDate,
+                                Title = calendarEvent.SchoolCalendarEvent.Title,
+                                Description = calendarEvent.SchoolCalendarEvent.Description,
+                                VisibleToMembershipId = targetVisibleToMembershipId,
+                                EventColor = calendarEvent.SchoolCalendarEvent.EventColor,
+                                IsHoliday = calendarEvent.SchoolCalendarEvent.IsHoliday,
+                                ApplicableToAllSchool = false,
+                                SystemWideEvent = false,
+                                CreatedBy = calendarEvent.SchoolCalendarEvent.CreatedBy,
+                                CreatedOn = DateTime.UtcNow
+                            };
+
+                            this.context?.CalendarEvents.Add(copy);
+                        }
+                    }
+                    // Super Admin: flags are left as-is (original behavior)
+                }
+            }
+
             this.context?.CalendarEvents.Add(calendarEvent.SchoolCalendarEvent);
             this.context?.SaveChanges();
             calendarEvent._failure = false;
@@ -179,7 +307,7 @@ namespace opensis.data.Repository
 
                 if (membershipData != null)
                 {
-                    var eventList = this.context?.CalendarEvents.AsEnumerable().Where(x => (((x.TenantId == calendarEventList.TenantId /*&& x.SchoolId == calendarEventList.SchoolId*/ && x.AcademicYear == calendarEventList.AcademicYear && ((calendarEventList.CalendarId!.Contains(x.CalendarId) /*&& x.SystemWideEvent == false */&& x.SchoolId == calendarEventList.SchoolId) || x.SystemWideEvent == true)) || x.TenantId == calendarEventList.TenantId && x.SystemWideEvent == true && x.AcademicYear == calendarEventList.AcademicYear) && (String.Compare(membershipData!.ProfileType, "Super Administrator", true) == 0  || String.Compare(membershipData!.ProfileType, "School Administrator", true) == 0 || String.Compare(membershipData!.ProfileType, "Admin Assistant", true) == 0 || (x.VisibleToMembershipId ?? "").Contains((calendarEventList.MembershipId ?? 0).ToString()))) || (x.TenantId == calendarEventList.TenantId && x.IsHoliday==true && (x.SchoolId== calendarEventList.SchoolId||x.ApplicableToAllSchool==true))).OrderBy(x => x.Title).ToList();
+                    var eventList = this.context?.CalendarEvents.AsEnumerable().Where(x => (((x.TenantId == calendarEventList.TenantId /*&& x.SchoolId == calendarEventList.SchoolId*/ && x.AcademicYear == calendarEventList.AcademicYear && x.IsHoliday != true && ((calendarEventList.CalendarId!.Contains(x.CalendarId) /*&& x.SystemWideEvent == false */&& x.SchoolId == calendarEventList.SchoolId) || x.SystemWideEvent == true)) || x.TenantId == calendarEventList.TenantId && x.SystemWideEvent == true && x.IsHoliday != true && x.AcademicYear == calendarEventList.AcademicYear) && (String.Compare(membershipData!.ProfileType, "Super Administrator", true) == 0  || String.Compare(membershipData!.ProfileType, "School Administrator", true) == 0 || String.Compare(membershipData!.ProfileType, "Admin Assistant", true) == 0 || (x.VisibleToMembershipId ?? "").Contains((calendarEventList.MembershipId ?? 0).ToString()))) || (x.TenantId == calendarEventList.TenantId && x.IsHoliday==true && (x.SchoolId== calendarEventList.SchoolId||x.ApplicableToAllSchool==true))).OrderBy(x => x.Title).ToList();
                     if(eventList!=null && eventList.Any())
                     {
                         calendarEventListViewModel.CalendarEventList = eventList;

--- a/API/opensis.data/Repository/CommonRepository.cs
+++ b/API/opensis.data/Repository/CommonRepository.cs
@@ -3261,7 +3261,9 @@ namespace opensis.data.Repository
                         dashboardView.SchoolCalendar!.SchoolMaster = null!;
                     }
 
-                    Events = this.context?.CalendarEvents.Where(x => x.TenantId == dashboardViewModel.TenantId && x.AcademicYear == dashboardViewModel.AcademicYear && (x.VisibleToMembershipId ?? "").Contains((dashboardViewModel.MembershipId ?? 0).ToString()) && ((x.StartDate <= DateTime.Today.Date && DateTime.Today.Date <= x.EndDate) || (x.StartDate >= DateTime.Today.Date)) && (x.SchoolId == dashboardViewModel.SchoolId || x.SystemWideEvent == true)).ToList();
+                    var membershipData = this.context?.Membership.FirstOrDefault(d => d.TenantId == dashboardViewModel.TenantId && d.SchoolId == dashboardViewModel.SchoolId && d.MembershipId == dashboardViewModel.MembershipId);
+
+                    Events = this.context?.CalendarEvents.AsEnumerable().Where(x => x.TenantId == dashboardViewModel.TenantId && x.AcademicYear == dashboardViewModel.AcademicYear && x.IsHoliday != true && (String.Compare(membershipData?.ProfileType, "Super Administrator", true) == 0 || String.Compare(membershipData?.ProfileType, "School Administrator", true) == 0 || String.Compare(membershipData?.ProfileType, "Admin Assistant", true) == 0 || (x.VisibleToMembershipId ?? "").Contains((dashboardViewModel.MembershipId ?? 0).ToString())) && ((x.StartDate <= DateTime.Today.Date && DateTime.Today.Date <= x.EndDate) || (x.StartDate >= DateTime.Today.Date)) && (x.SchoolId == dashboardViewModel.SchoolId || x.SystemWideEvent == true)).ToList();
 
                     //for fetch holiday
                     var holidays = this.context?.CalendarEvents.Where(x => x.TenantId == dashboardViewModel.TenantId && x.AcademicYear == dashboardViewModel.AcademicYear && ((x.StartDate <= DateTime.Today.Date && DateTime.Today.Date <= x.EndDate) || (x.StartDate >= DateTime.Today.Date)) && x.IsHoliday == true && (x.SchoolId == dashboardViewModel.SchoolId || x.ApplicableToAllSchool == true)).ToList();

--- a/API/opensis.data/Repository/NoticeRepository.cs
+++ b/API/opensis.data/Repository/NoticeRepository.cs
@@ -23,6 +23,7 @@ Copyright (c) Open Solutions for Education, Inc.
 All rights reserved.
 ***********************************************************************************/
 
+using Microsoft.EntityFrameworkCore;
 using opensis.data.Helper;
 using opensis.data.Interface;
 using opensis.data.Models;
@@ -73,12 +74,127 @@ namespace opensis.data.Repository
                     notice.Notice.NoticeId = (int)noticeId;
                     notice.Notice.Isactive = true;
                     notice.Notice.CreatedOn = DateTime.UtcNow;
+
+                    // When "Visible to All School" is requested, scope to the creator's authorized schools.
+                    // Super Admins keep the flag (visible to all schools).
+                    // School Admins get individual copies at each school they administer.
+                    if (notice.Notice.VisibleToAllSchool && !string.IsNullOrEmpty(notice.Notice.CreatedBy))
+                    {
+                        var staffMember = this.context?.StaffMaster
+                            .FirstOrDefault(s => s.TenantId == notice.Notice.TenantId
+                                && s.StaffGuid.ToString() == notice.Notice.CreatedBy);
+
+                        if (staffMember != null)
+                        {
+                            var activeAssignments = this.context?.StaffSchoolInfo
+                                .Include(s => s.Membership)
+                                .Where(s => s.TenantId == notice.Notice.TenantId
+                                    && s.StaffId == staffMember.StaffId
+                                    && (s.EndDate == null || s.EndDate.Value.Date >= DateTime.UtcNow.Date)
+                                    && s.StartDate <= DateTime.UtcNow.Date)
+                                .ToList();
+
+                            // Check Super Admin via StaffSchoolInfo first, then fall back to UserMaster
+                            // (Super Admins may not have StaffSchoolInfo entries — they access all schools via UserMaster.Membership)
+                            var isSuperAdmin = activeAssignments?.Any(s =>
+                                string.Equals(s.Membership?.ProfileType, "Super Administrator", StringComparison.OrdinalIgnoreCase)) ?? false;
+
+                            if (!isSuperAdmin)
+                            {
+                                isSuperAdmin = this.context?.UserMaster
+                                    .Include(u => u.Membership)
+                                    .Any(u => u.TenantId == notice.Notice.TenantId
+                                        && u.UserId == staffMember.StaffId
+                                        && (u.Membership!.IsSuperadmin == true
+                                            || u.Membership.ProfileType!.ToLower() == "super administrator")) ?? false;
+                            }
+
+                            if (!isSuperAdmin)
+                            {
+                                var targetSchoolIds = activeAssignments?
+                                    .Where(s => string.Equals(s.Membership?.ProfileType, "School Administrator", StringComparison.OrdinalIgnoreCase)
+                                        && s.SchoolAttachedId != null
+                                        && s.SchoolAttachedId != notice.Notice.SchoolId)
+                                    .Select(s => s.SchoolAttachedId!.Value)
+                                    .Distinct()
+                                    .ToList() ?? new List<int>();
+
+                                // Resolve source membership profile types for target translation
+                                List<string?>? sourceProfileTypes = null;
+                                if (!string.IsNullOrEmpty(notice.Notice.TargetMembershipIds))
+                                {
+                                    var sourceMembershipIds = notice.Notice.TargetMembershipIds
+                                        .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                                        .Select(int.Parse)
+                                        .ToList();
+
+                                    sourceProfileTypes = this.context?.Membership
+                                        .Where(m => m.TenantId == notice.Notice.TenantId
+                                            && m.SchoolId == notice.Notice.SchoolId
+                                            && sourceMembershipIds.Contains(m.MembershipId))
+                                        .Select(m => m.ProfileType)
+                                        .ToList();
+                                }
+
+                                notice.Notice.VisibleToAllSchool = false;
+
+                                foreach (var targetSchoolId in targetSchoolIds)
+                                {
+                                    // Notice IDs are per-school
+                                    int targetNoticeId = 1;
+                                    var lastNotice = this.context?.Notice
+                                        .Where(x => x.SchoolId == targetSchoolId && x.TenantId == notice.Notice.TenantId)
+                                        .OrderByDescending(x => x.NoticeId)
+                                        .FirstOrDefault();
+                                    if (lastNotice != null)
+                                    {
+                                        targetNoticeId = lastNotice.NoticeId + 1;
+                                    }
+
+                                    // Translate membership visibility to the target school
+                                    string targetMembershipIds = notice.Notice.TargetMembershipIds;
+                                    if (sourceProfileTypes != null)
+                                    {
+                                        var targetIds = this.context?.Membership
+                                            .Where(m => m.TenantId == notice.Notice.TenantId
+                                                && m.SchoolId == targetSchoolId
+                                                && sourceProfileTypes.Contains(m.ProfileType))
+                                            .Select(m => m.MembershipId)
+                                            .ToList() ?? new List<int>();
+
+                                        targetMembershipIds = string.Join(",", targetIds);
+                                    }
+
+                                    var copy = new Notice
+                                    {
+                                        TenantId = notice.Notice.TenantId,
+                                        SchoolId = targetSchoolId,
+                                        NoticeId = targetNoticeId,
+                                        TargetMembershipIds = targetMembershipIds,
+                                        Title = notice.Notice.Title,
+                                        Body = notice.Notice.Body,
+                                        ValidFrom = notice.Notice.ValidFrom,
+                                        ValidTo = notice.Notice.ValidTo,
+                                        Isactive = true,
+                                        VisibleToAllSchool = false,
+                                        SortOrder = notice.Notice.SortOrder,
+                                        CreatedBy = notice.Notice.CreatedBy,
+                                        CreatedOn = DateTime.UtcNow
+                                    };
+
+                                    this.context?.Notice.Add(copy);
+                                }
+                            }
+                            // Super Admin: flag is left as-is (original behavior)
+                        }
+                    }
+
                     this.context?.Notice.Add(notice.Notice);
                     this.context?.SaveChanges();
                     notice._failure = false;
                     notice._message = "Notice added successfully";
                 }
-                
+
                 return notice;
             }
             catch (Exception ex)

--- a/UI/src/app/pages/school/calendar/add-event/add-event.component.html
+++ b/UI/src/app/pages/school/calendar/add-event/add-event.component.html
@@ -130,10 +130,16 @@
                             </li>
 
                         </ul>
-                        <div class="mb-4 mt-4" *ngIf="this.defaultValuesService.getUserMembershipType() === profiles.SuperAdmin">
+                        <div class="mb-4 mt-4" *ngIf="this.defaultValuesService.getUserMembershipType() === profiles.SuperAdmin || this.defaultValuesService.getUserMembershipType() === profiles.SchoolAdmin">
                             <mat-slide-toggle color="primary" formControlName="systemWideEvent">
                                 {{'applyToAllSchools' | translate}}
                             </mat-slide-toggle>
+                            <div *ngIf="isSchoolAdmin && userSchoolNames.length > 0" class="mt-1 ml-12 text-xs text-hint cursor-pointer" (click)="toggleSchoolList()">
+                                ({{userSchoolNames.length}} {{'schools' | translate}}) {{showSchoolList ? '&#9650;' : '&#9660;'}}
+                            </div>
+                            <ul *ngIf="isSchoolAdmin && showSchoolList" class="mt-1 ml-12 text-sm list-disc" style="max-height: 120px; overflow-y: auto;">
+                                <li *ngFor="let name of userSchoolNames">{{name}}</li>
+                            </ul>
                         </div>
 
                     </div>
@@ -188,10 +194,16 @@
                             <mat-label>{{'notes' | translate}}</mat-label>
                             <textarea formControlName="notes" name="notes" cdkFocusInitial matInput></textarea>
                         </mat-form-field>
-                        <div class="my-2" *ngIf="this.defaultValuesService.getUserMembershipType() === profiles.SuperAdmin">
+                        <div class="my-2" *ngIf="this.defaultValuesService.getUserMembershipType() === profiles.SuperAdmin || this.defaultValuesService.getUserMembershipType() === profiles.SchoolAdmin">
                             <mat-slide-toggle color="primary" formControlName="applicableToAllSchool">
                                 {{'applyToAllSchools' | translate}}
                             </mat-slide-toggle>
+                            <div *ngIf="isSchoolAdmin && userSchoolNames.length > 0" class="mt-1 ml-12 text-xs text-hint cursor-pointer" (click)="toggleSchoolList()">
+                                ({{userSchoolNames.length}} {{'schools' | translate}}) {{showSchoolList ? '&#9650;' : '&#9660;'}}
+                            </div>
+                            <ul *ngIf="isSchoolAdmin && showSchoolList" class="mt-1 ml-12 text-sm list-disc" style="max-height: 120px; overflow-y: auto;">
+                                <li *ngFor="let name of userSchoolNames">{{name}}</li>
+                            </ul>
                         </div>
                     </div>
                 </mat-dialog-content>
@@ -256,10 +268,14 @@
                         <mat-label>{{'notes' | translate}}</mat-label>
                         <textarea formControlName="notes" name="notes" cdkFocusInitial matInput></textarea>
                     </mat-form-field>
-                    <div class="my-2" *ngIf="this.defaultValuesService.getUserMembershipType() === profiles.SuperAdmin">
+                    <div class="my-2" *ngIf="this.defaultValuesService.getUserMembershipType() === profiles.SuperAdmin || this.defaultValuesService.getUserMembershipType() === profiles.SchoolAdmin">
                         <mat-slide-toggle color="primary" formControlName="applicableToAllSchool">
                             {{'applyToAllSchools' | translate}}
                         </mat-slide-toggle>
+                        <span *ngIf="isSchoolAdmin && userSchoolNames.length > 0" class="ml-2 text-xs text-hint cursor-pointer" (click)="toggleSchoolList()">({{userSchoolNames.length}} {{'schools' | translate}}) {{showSchoolList ? '&#9650;' : '&#9660;'}}</span>
+                        <ul *ngIf="isSchoolAdmin && showSchoolList" class="mt-2 ml-6 text-sm list-disc" style="max-height: 120px; overflow-y: auto;">
+                            <li *ngFor="let name of userSchoolNames">{{name}}</li>
+                        </ul>
                     </div>
                 </div>
             </mat-dialog-content>

--- a/UI/src/app/pages/school/calendar/add-event/add-event.component.ts
+++ b/UI/src/app/pages/school/calendar/add-event/add-event.component.ts
@@ -51,6 +51,8 @@ import { DefaultValuesService } from '../../../../common/default-values.service'
 import { PageRolesPermission } from '../../../../common/page-roles-permissions.service';
 import { CommonService } from 'src/app/services/common.service';
 import { ProfilesTypes } from 'src/app/enums/profiles.enum';
+import { SchoolService } from 'src/app/services/school.service';
+import { OnlySchoolListModel } from 'src/app/models/get-all-school.model';
 
 
 @Component({
@@ -77,6 +79,9 @@ export class AddEventComponent implements OnInit {
   membercount: number;
   memberArray: number[] = [];
   currentTab: string;
+  userSchoolNames: string[] = [];
+  showSchoolList: boolean = false;
+  isSchoolAdmin: boolean = false;
 
   colors: colors[] = [
     { name: 'Red', value: '#f44336' },
@@ -112,7 +117,8 @@ export class AddEventComponent implements OnInit {
     private fb: FormBuilder,
     public defaultValuesService: DefaultValuesService,
     private commonService: CommonService,
-    private el: ElementRef
+    private el: ElementRef,
+    private schoolService: SchoolService
   ) {
     this.translate.setDefaultLang('en');
     this.form = this.fb.group({
@@ -130,6 +136,10 @@ export class AddEventComponent implements OnInit {
   ngOnInit(): void {
     this.permissions = this.pageRolePermissions.checkPageRolePermission();
     this.currentTab = 'event';
+    this.isSchoolAdmin = this.defaultValuesService.getUserMembershipType() === this.profiles.SchoolAdmin;
+    if (this.isSchoolAdmin) {
+      this.loadUserSchools();
+    }
 
     if (this.data == null) {
       this.snackbar.open('Null value occur. ', '', {
@@ -415,6 +425,22 @@ export class AddEventComponent implements OnInit {
   }
   changeTab(status){
     this.currentTab = status;
+  }
+
+  loadUserSchools() {
+    let schoolListModel = new OnlySchoolListModel();
+    schoolListModel.emailAddress = this.defaultValuesService.getEmailId();
+    this.schoolService.GetAllSchools(schoolListModel).subscribe((data: any) => {
+      if (data.getSchoolForView?.length > 0) {
+        this.userSchoolNames = data.getSchoolForView
+          .filter(s => s.membershipType === this.profiles.SchoolAdmin)
+          .map(s => s.schoolName);
+      }
+    });
+  }
+
+  toggleSchoolList() {
+    this.showSchoolList = !this.showSchoolList;
   }
 
 }

--- a/UI/src/app/pages/school/notices/edit-notice/edit-notice.component.html
+++ b/UI/src/app/pages/school/notices/edit-notice/edit-notice.component.html
@@ -46,8 +46,16 @@
                         type="number" min="1" matInput>
                 </mat-form-field>
             </div>
-            <div class="flex flex-1 mx-6 md:w-1/2 md:mt-4" *ngIf="this.defaultValuesService.getUserMembershipType() === profiles.SuperAdmin">
-                <mat-checkbox [checked]="schoolVisibility" (change)="schoolVisibilityCheck($event) " color="primary">{{'visibleToAllSchool' | translate}}</mat-checkbox>
+            <div class="flex flex-1 mx-6 md:w-1/2 md:mt-4" *ngIf="this.defaultValuesService.getUserMembershipType() === profiles.SuperAdmin || this.defaultValuesService.getUserMembershipType() === profiles.SchoolAdmin">
+                <div>
+                    <mat-checkbox [checked]="schoolVisibility" (change)="schoolVisibilityCheck($event) " color="primary">{{'visibleToAllSchool' | translate}}</mat-checkbox>
+                    <div *ngIf="isSchoolAdmin && userSchoolNames.length > 0" class="mt-1 ml-6 text-xs text-hint cursor-pointer" (click)="toggleSchoolList()">
+                        ({{userSchoolNames.length}} {{'schools' | translate}}) {{showSchoolList ? '&#9650;' : '&#9660;'}}
+                    </div>
+                    <ul *ngIf="isSchoolAdmin && showSchoolList" class="mt-1 ml-6 text-sm list-disc" style="max-height: 120px; overflow-y: auto;">
+                        <li *ngFor="let name of userSchoolNames">{{name}}</li>
+                    </ul>
+                </div>
             </div>
         </div>
         

--- a/UI/src/app/pages/school/notices/edit-notice/edit-notice.component.ts
+++ b/UI/src/app/pages/school/notices/edit-notice/edit-notice.component.ts
@@ -47,6 +47,8 @@ import { MatCheckbox } from '@angular/material/checkbox';
 import { DefaultValuesService } from '../../../../common/default-values.service';
 import { CommonService } from 'src/app/services/common.service';
 import { ProfilesTypes } from 'src/app/enums/profiles.enum';
+import { SchoolService } from 'src/app/services/school.service';
+import { OnlySchoolListModel } from 'src/app/models/get-all-school.model';
 
 @Component({
   selector: 'vex-edit-notice',
@@ -80,6 +82,9 @@ export class EditNoticeComponent implements OnInit {
   schoolVisibility = false;
   profileError: boolean;
   profiles = ProfilesTypes;
+  userSchoolNames: string[] = [];
+  showSchoolList: boolean = false;
+  isSchoolAdmin: boolean = false;
   @ViewChild('scrollBottom') private scrollBottom: ElementRef;
 
   constructor(
@@ -92,7 +97,8 @@ export class EditNoticeComponent implements OnInit {
               private loaderService: LoaderService,
               public defaultValuesService: DefaultValuesService,
     private commonService: CommonService,
-    private el: ElementRef
+    private el: ElementRef,
+    private schoolService: SchoolService
     ) {
     //translateService.use('en');
     this.loaderService.isLoading.subscribe((v) => {
@@ -103,6 +109,10 @@ export class EditNoticeComponent implements OnInit {
 
 
   ngOnInit(): void {
+    this.isSchoolAdmin = this.defaultValuesService.getUserMembershipType() === this.profiles.SchoolAdmin;
+    if (this.isSchoolAdmin) {
+      this.loadUserSchools();
+    }
     if(this.data==null){
       this.snackbar.open('Null vallue occur. ', '', {
         duration: 10000
@@ -311,6 +321,22 @@ export class EditNoticeComponent implements OnInit {
       this.checkBox.checked=false;
     }
     this.checkProfileError()
+  }
+
+  loadUserSchools() {
+    let schoolListModel = new OnlySchoolListModel();
+    schoolListModel.emailAddress = this.defaultValuesService.getEmailId();
+    this.schoolService.GetAllSchools(schoolListModel).subscribe((data: any) => {
+      if (data.getSchoolForView?.length > 0) {
+        this.userSchoolNames = data.getSchoolForView
+          .filter(s => s.membershipType === this.profiles.SchoolAdmin)
+          .map(s => s.schoolName);
+      }
+    });
+  }
+
+  toggleSchoolList() {
+    this.showSchoolList = !this.showSchoolList;
   }
 
 }

--- a/UI/src/app/services/dasboard.service.ts
+++ b/UI/src/app/services/dasboard.service.ts
@@ -42,6 +42,7 @@ export class DasboardService {
   getDashboardViewForCalendarView(obj: DashboardViewModel) {
     obj = this.defaultValuesService.getAllMandatoryVariable(obj);
     obj.academicYear= this.defaultValuesService.getAcademicYear();
+    obj.membershipId= +this.defaultValuesService.getuserMembershipID();
     let apiurl = this.apiUrl + obj._tenantName + "/Common/getDashboardViewForCalendarView";
     return this.http.post<DashboardViewModel>(apiurl, obj,this.httpOptions)
   }


### PR DESCRIPTION
…ools

When a School Administrator uses "Apply to All Schools" for calendar events, holidays, or notices, it now creates individual copies only at schools where they are School Administrator — not every school in the system. Super Administrators retain the original system-wide behavior.

The toggle is now visible to School Admins with a collapsible list showing which schools will be affected.

Also fixes: dashboard calendar events not showing due to missing membershipId, and duplicate holiday display in both calendar and dashboard caused by holidays matching both event and holiday query branches.

Resolves #437